### PR TITLE
Fix `DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats`

### DIFF
--- a/pyeasyecc.cpp
+++ b/pyeasyecc.cpp
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // crypto++

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     name='easyecc',
     description='''A simple wrapper around Crypto++ for Elliptical Curve Cryptography''',
     url='https://github.com/cureatr/easyecc',
-    version='0.4',
+    version='0.5',
     author='Alex Khomenko',
     author_email='khomenko@cs.stanford.edu',
     ext_modules=modules,


### PR DESCRIPTION
Bump version to 0.5